### PR TITLE
Update StopOnRevertHandler.t.sol

### DIFF
--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -57,13 +57,13 @@ contract StopOnRevertHandler is Test {
 
     function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
         ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
-        uint256 maxCollateral = dscEngine.getCollateralBalanceOfUser(address(collateral), msg.sender);
+        uint256 maxCollateral = dscEngine.getCollateralBalanceOfUser(msg.sender, address(collateral));
 
         amountCollateral = bound(amountCollateral, 0, maxCollateral);
-        if (amountCollateral == 0) {
-            return;
-        }
-        dscEngine.redeemCollateral(address(collateral), amountCollateral);
+            if (amountCollateral == 0) {
+                return;
+            }
+            dscEngine.redeemCollateral(address(collateral), amountCollateral);
     }
 
     function burnDsc(uint256 amountDsc) public {


### PR DESCRIPTION
In DSCEngine.sol we have the params with user first, then collateral

```solidity
    function getCollateralBalanceOfUser(address user, address token) external view returns (uint256) {
        return s_collateralDeposited[user][token];
    }
```

```solidity
    function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
        ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
        uint256 maxCollateral = dscEngine.getCollateralBalanceOfUser(address(collateral), msg.sender);

        amountCollateral = bound(amountCollateral, 0, maxCollateral);
        if (amountCollateral == 0) {
            return;
        }
        dscEngine.redeemCollateral(address(collateral), amountCollateral);
    }
```
In the current Handler file above (which I am suggesting needs editing) we are calling collateral first and user second, I found this whilst running Handler.t.sol locally at this point in the video course (https://youtu.be/wUjYK5gwNZs?t=14989). The video tests run perfectly, my local tests however, have under/overflow arithmetic errors.


I have the params in the correct order,
```solidity
dsce.getCollateralBalanceOfUser(msg.sender, address(collateral));
```
and these are the errors from my invariant test
```bash
Encountered 1 failing test in test/fuzz/InvariantsTest.t.sol:InvariantsTest
[FAIL. Reason: Arithmetic over/underflow]
        [Sequence]
                sender=0x62084110fd5fc65ce932bd6425016f4d01abec6c addr=[test/fuzz/Handler.t.sol:Handler]0x2e234dae75c793f67a35089c9d99245e1c58470b calldata=depositCollateral(uint256,uint256), args=[966458702 [9.664e8], 3]
```

This has been edited in place, no tests have been run on the repository - only my local version which is not yet finished