### PR TITLE
Mentioned the openzeppelin version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project is meant to be a stablecoin where users can deposit WETH and WBTC i
   - [Requirements](#requirements)
   - [Quickstart](#quickstart)
     - [Optional Gitpod](#optional-gitpod)
+- [Updates](#updates)
 - [Usage](#usage)
   - [Start a local node](#start-a-local-node)
   - [Deploy](#deploy)
@@ -49,6 +50,9 @@ forge build
 If you can't or don't want to run and install locally, you can work with this repo in Gitpod. If you do this, you can skip the `clone this repo` part.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#github.com/PatrickAlphaC/foundry-smart-contract-lottery-f23)
+
+# Updates
+- The latest version of openzeppelin-contracts has changes in the ERC20Mock file. To follow along with the course, you need to install version 4.8.3 which can be done by ```forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit``` instead of ```forge install openzeppelin/openzeppelin-contracts --no-commit```
 
 # Usage
 


### PR DESCRIPTION
The latest openzeppelin-contracts release has changes in the ERC20Mock file. I mentioned the version we use (4.8.3) in the README.md file.

closes #15