### PR TITLE
fixed call to calculateHealthFactor in tests

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -240,7 +240,7 @@ contract DSCEngineTest is StdCheats, Test {
         dsce.depositCollateral(weth, amountCollateral);
 
         uint256 expectedHealthFactor =
-            dsce.calculateHealthFactor(dsce.getUsdValue(weth, amountCollateral), amountToMint);
+            dsce.calculateHealthFactor(amountToMint, dsce.getUsdValue(weth, amountCollateral));
         vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__BreaksHealthFactor.selector, expectedHealthFactor));
         dsce.mintDsc(amountToMint);
         vm.stopPrank();

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -175,7 +175,7 @@ contract DSCEngineTest is StdCheats, Test {
         ERC20Mock(weth).approve(address(dsce), amountCollateral);
 
         uint256 expectedHealthFactor =
-            dsce.calculateHealthFactor(dsce.getUsdValue(weth, amountCollateral), amountToMint);
+            dsce.calculateHealthFactor(amountToMint, dsce.getUsdValue(weth, amountCollateral));
         vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__BreaksHealthFactor.selector, expectedHealthFactor));
         dsce.depositCollateralAndMintDsc(weth, amountCollateral, amountToMint);
         vm.stopPrank();


### PR DESCRIPTION
`calculateHealthFactor` takes in the `totalDscMinted` as the first argument and `collateralValueInUsd` as the second argument. The call to `calculateHealthFactor` had this order switched. The tests were still passing since both the arguments had equal values in our case. However, I thought it would be better if we pass the arguments to the appropriate parameters so I have fixed the order of the arguments. The tests still pass after the modification.

Please let me know in case I have made any misinterpretations. Thanks!