### PR TITLE
corrected calculation of expectedWeth in tests

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -469,7 +469,7 @@ contract DSCEngineTest is StdCheats, Test {
     function testUserStillHasSomeEthAfterLiquidation() public liquidated {
         // Get how much WETH the user lost
         uint256 amountLiquidated = dsce.getTokenAmountFromUsd(weth, amountToMint)
-            + (dsce.getTokenAmountFromUsd(weth, amountToMint) / dsce.getLiquidationBonus());
+            + ((dsce.getTokenAmountFromUsd(weth, amountToMint) * dsce.getLiquidationBonus()) / 100);
 
         uint256 usdAmountLiquidated = dsce.getUsdValue(weth, amountLiquidated);
         uint256 expectedUserCollateralValueInUsd = dsce.getUsdValue(weth, amountCollateral) - (usdAmountLiquidated);

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -460,7 +460,7 @@ contract DSCEngineTest is StdCheats, Test {
     function testLiquidationPayoutIsCorrect() public liquidated {
         uint256 liquidatorWethBalance = ERC20Mock(weth).balanceOf(liquidator);
         uint256 expectedWeth = dsce.getTokenAmountFromUsd(weth, amountToMint)
-            + (dsce.getTokenAmountFromUsd(weth, amountToMint) / dsce.getLiquidationBonus());
+            + ((dsce.getTokenAmountFromUsd(weth, amountToMint) * dsce.getLiquidationBonus()) / 100);
         uint256 hardCodedExpected = 6111111111111111110;
         assertEq(liquidatorWethBalance, hardCodedExpected);
         assertEq(liquidatorWethBalance, expectedWeth);


### PR DESCRIPTION
**PROBLEM:**
I suspected that the calculation of `expectedWeth` was not correct in the tests.

**EVIDENCE:**
I checked this by changing the `LIQUIDATION_BONUS` constant to 20 in 'DSCEngine.sol'. The assert `assertEq(liquidatorWethBalance, expectedWeth)` was failing after making the change.

**EXPLANATION:**
The test was passing in our case because our `LIQUIDATION_BONUS` is 10 and the operations `x / 10` and `(x * 10) / 100` are equivalent. If we change the bonus from 10 to some other number, the calculation breaks.

**SOLUTION:**
I have corrected the formula and the tests are passing. Please let me know if you think there is a misinterpretation on my end. Thanks!