### PR TITLE
corrected contract name for OracleLibTest

### DIFF
--- a/test/unit/OracleLibTest.t.sol
+++ b/test/unit/OracleLibTest.t.sol
@@ -7,7 +7,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {StdCheats} from "forge-std/StdCheats.sol";
 import {OracleLib, AggregatorV3Interface} from "../../src/libraries/OracleLib.sol";
 
-contract DSCEngineTest is StdCheats, Test {
+contract OracleLibTest is StdCheats, Test {
     using OracleLib for AggregatorV3Interface;
 
     MockV3Aggregator public aggregator;


### PR DESCRIPTION
Since here we are testing `OracleLib.sol` and we already have a contract named `DSCEngineTest` in `DSCEngineTest.t.sol` that is testing `DSCEngine.sol`, I thought it would be more appropriate if this test contract was named `OracleLibTest` instead of `DSCEngineTest`.