### PR TITLE
Update DecentralizedStableCoin.sol - Added Ownable comments

### DIFF
--- a/src/DecentralizedStableCoin.sol
+++ b/src/DecentralizedStableCoin.sol
@@ -43,6 +43,13 @@ contract DecentralizedStableCoin is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__BurnAmountExceedsBalance();
     error DecentralizedStableCoin__NotZeroAddress();
 
+    /*
+    In future versions of OpenZeppelin contracts package, Ownable must be declared with an address of the contract owner as a parameter.
+    For example:
+    constructor() ERC20("DecentralizedStableCoin", "DSC") Ownable(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266) {}
+    Related code changes can be viewed in this commit:
+    https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60
+    */
     constructor() ERC20("DecentralizedStableCoin", "DSC") {}
 
     function burn(uint256 _amount) public override onlyOwner {


### PR DESCRIPTION
Ownable's initial owner must be explicitly entered in the constructor, added comments to clarify this for future versions of OpenZeppelin contracts.
[Relative changes](https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60)