### PR TITLE
Ownable update

### DIFF
--- a/src/DecentralizedStableCoin.sol
+++ b/src/DecentralizedStableCoin.sol
@@ -43,6 +43,13 @@ contract DecentralizedStableCoin is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__BurnAmountExceedsBalance();
     error DecentralizedStableCoin__NotZeroAddress();
 
+    /*
+    In future versions of OpenZeppelin contracts package, Ownable must be declared with an address of the contract owner as a parameter.
+    For example:
+    constructor() ERC20("DecentralizedStableCoin", "DSC") Ownable(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266) {}
+    Related code changes can be viewed in this commit:
+    https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60
+    */
     constructor() ERC20("DecentralizedStableCoin", "DSC") {}
 
     function burn(uint256 _amount) public override onlyOwner {

--- a/test/mocks/MockFailedMintDSC.sol
+++ b/test/mocks/MockFailedMintDSC.sol
@@ -9,6 +9,13 @@ contract MockFailedMintDSC is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__BurnAmountExceedsBalance();
     error DecentralizedStableCoin__NotZeroAddress();
 
+    /*
+    In future versions of OpenZeppelin contracts package, Ownable must be declared with an address of the contract owner as a parameter.
+    For example:
+    constructor() ERC20("DecentralizedStableCoin", "DSC") Ownable(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266) {}
+    Related code changes can be viewed in this commit:
+    https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60
+    */
     constructor() ERC20("DecentralizedStableCoin", "DSC") {}
 
     function burn(uint256 _amount) public override onlyOwner {

--- a/test/mocks/MockFailedTransfer.sol
+++ b/test/mocks/MockFailedTransfer.sol
@@ -9,6 +9,13 @@ contract MockFailedTransfer is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__BurnAmountExceedsBalance();
     error DecentralizedStableCoin__NotZeroAddress();
 
+    /*
+    In future versions of OpenZeppelin contracts package, Ownable must be declared with an address of the contract owner as a parameter.
+    For example:
+    constructor() ERC20("DecentralizedStableCoin", "DSC") Ownable(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266) {}
+    Related code changes can be viewed in this commit:
+    https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60
+    */
     constructor() ERC20("DecentralizedStableCoin", "DSC") {}
 
     function burn(uint256 _amount) public override onlyOwner {

--- a/test/mocks/MockFailedTransferFrom.sol
+++ b/test/mocks/MockFailedTransferFrom.sol
@@ -9,6 +9,13 @@ contract MockFailedTransferFrom is ERC20Burnable, Ownable {
     error DecentralizedStableCoin__BurnAmountExceedsBalance();
     error DecentralizedStableCoin__NotZeroAddress();
 
+    /*
+    In future versions of OpenZeppelin contracts package, Ownable must be declared with an address of the contract owner as a parameter.
+    For example:
+    constructor() ERC20("DecentralizedStableCoin", "DSC") Ownable(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266) {}
+    Related code changes can be viewed in this commit:
+    https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60
+    */
     constructor() ERC20("DecentralizedStableCoin", "DSC") {}
 
     function burn(uint256 _amount) public override onlyOwner {

--- a/test/mocks/MockMoreDebtDSC.sol
+++ b/test/mocks/MockMoreDebtDSC.sol
@@ -46,6 +46,13 @@ contract MockMoreDebtDSC is ERC20Burnable, Ownable {
 
     address mockAggregator;
 
+    /*
+    In future versions of OpenZeppelin contracts package, Ownable must be declared with an address of the contract owner as a parameter.
+    For example:
+    constructor() ERC20("DecentralizedStableCoin", "DSC") Ownable(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266) {}
+    Related code changes can be viewed in this commit:
+    https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60
+    */
     constructor(address _mockAggregator) ERC20("DecentralizedStableCoin", "DSC") {
         mockAggregator = _mockAggregator;
     }


### PR DESCRIPTION
Ownable's initial owner must be explicitly entered in the constructor, added comments to clarify this for future versions of OpenZeppelin contracts.
[Related Changes](https://github.com/OpenZeppelin/openzeppelin-contracts/commit/13d5e0466a9855e9305119ed383e54fc913fdc60)