### PR TITLE
update collateralRedeemEvent to pass proper args

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -88,7 +88,7 @@ contract DSCEngine is ReentrancyGuard {
     // Events
     ///////////////////
     event CollateralDeposited(address indexed user, address indexed token, uint256 indexed amount);
-    event CollateralRedeemed(address indexed redeemedFrom, uint256 indexed amountCollateral, address from, address to); // if from != to, then it was liquidated
+    event CollateralRedeemed(address indexed redeemFrom, address indexed redeemTo, address token, uint256 amount); // if redeemFrom != redeemedTo, then it was liquidated
 
     ///////////////////
     // Modifiers
@@ -265,7 +265,7 @@ contract DSCEngine is ReentrancyGuard {
         private
     {
         s_collateralDeposited[from][tokenCollateralAddress] -= amountCollateral;
-        emit CollateralRedeemed(from, amountCollateral, from, to);
+        emit CollateralRedeemed(from, to, tokenCollateralAddress, amountCollateral);
         bool success = IERC20(tokenCollateralAddress).transfer(to, amountCollateral);
         if (!success) {
             revert DSCEngine__TransferFailed();

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -16,6 +16,8 @@ import {Test, console} from "forge-std/Test.sol";
 import {StdCheats} from "forge-std/StdCheats.sol";
 
 contract DSCEngineTest is StdCheats, Test {
+    event CollateralRedeemed(address indexed redeemFrom, address indexed redeemTo, address token, uint256 amount); // if redeemFrom != redeemedTo, then it was liquidated
+
     DSCEngine public dsce;
     DecentralizedStableCoin public dsc;
     HelperConfig public helperConfig;
@@ -332,6 +334,13 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
+    function testEmitCollateralRedeemedWithCorrectArgs() public depositedCollateral {
+        vm.expectEmit(true, true, true, true, address(dsce));
+        emit CollateralRedeemed(user, user, weth, amountCollateral);
+        vm.startPrank(user);
+        dsce.redeemCollateral(weth, amountCollateral);
+        vm.stopPrank();
+    }
     ///////////////////////////////////
     // redeemCollateralForDsc Tests //
     //////////////////////////////////


### PR DESCRIPTION
There was a small issue with the way the props were passed to the CollateralRedeemed event.

previous the event looks like 
```event CollateralRedeemed(address indexed redeemedFrom, uint256 indexed amountCollateral, address from, address to);```
and props passed to this was 

``` emit CollateralRedeemed(from, amountCollateral, from, to);```

The updated event is

```   event CollateralRedeemed(address indexed redeemFrom, address indexed redeemTo, address token, uint256 amount); ```

and updated props passed is 

```        emit CollateralRedeemed(from, to, tokenCollateralAddress, amountCollateral); ```