### PR TITLE
Update StopOnRevertHandler.t.sol

### DIFF
--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -63,6 +63,7 @@ contract StopOnRevertHandler is Test {
         if (amountCollateral == 0) {
             return;
         }
+        vm.prank(msg.sender);
         dscEngine.redeemCollateral(address(collateral), amountCollateral);
     }
 


### PR DESCRIPTION
`"Arithmetic over/underflow"` error is fixed by adding `vm.prank(msg.sender);` before calling `redeemCollateral` function, which was causing the invariant test to revert.