### PR TITLE
fix: broken _calculateHealthFactor when collateralValueInUsd is zero

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -315,7 +315,9 @@ contract DSCEngine is ReentrancyGuard {
         internal
         pure
         returns (uint256)
-    {
+    {   
+        // !IMPORTANT: "collateralValueInUsd" needs to be checked before "totalDscMinted"
+        if (collateralValueInUsd == 0) return 0;
         if (totalDscMinted == 0) return type(uint256).max;
         uint256 collateralAdjustedForThreshold = (collateralValueInUsd * LIQUIDATION_THRESHOLD) / 100;
         return (collateralAdjustedForThreshold * 1e18) / totalDscMinted;


### PR DESCRIPTION
[If we read this code,](https://github.com/Cyfrin/foundry-defi-stablecoin-f23/blob/e37b7a7e481c25c0bb14edfccc0234c1956b6a8b/src/DSCEngine.sol#L233). 

Its will check health factor and if that's okay, it will go ahead and mint DSC (which is also a public fn). 
but `_healthFactor() -> _calculateHealthFactor()` - checks if  dscMinted is/are 0, returns uin256.max. which indicates the factor factor is okay, even if NO COLLATERAL IS DEPOSITED. 


