### PR TITLE
fix comment on DSCEngineTest.t.sol

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -386,7 +386,7 @@ contract DSCEngineTest is StdCheats, Test {
         MockV3Aggregator(ethUsdPriceFeed).updateAnswer(ethUsdUpdatedPrice);
 
         uint256 userHealthFactor = dsce.getHealthFactor(user);
-        // $180 collateral / 200 debt = 0.9
+        // 180*50 (LIQUIDATION_THRESHOLD) / 100 (LIQUIDATION_PRECISION) / 100 (PRECISION) = 90 / 100 (totalDscMinted) = 0.9
         assert(userHealthFactor == 0.9 ether);
     }
 

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -381,7 +381,7 @@ contract DSCEngineTest is StdCheats, Test {
 
     function testHealthFactorCanGoBelowOne() public depositedCollateralAndMintedDsc {
         int256 ethUsdUpdatedPrice = 18e8; // 1 ETH = $18
-        // Rememeber, we need $150 at all times if we have $100 of debt
+        // Rememeber, we need $200 at all times if we have $100 of debt
 
         MockV3Aggregator(ethUsdPriceFeed).updateAnswer(ethUsdUpdatedPrice);
 


### PR DESCRIPTION
Changed a comment on DSCEngineTEst.t.sol : function testHealthFactorCanGoBelowOne() 

I this sentence I don't know where the "200 debt" come from
I put instead the detail of health factor calcul
// 180*50 (LIQUIDATION_THRESHOLD) / 100 (LIQUIDATION_PRECISION) / 100 (PRECISION) = 90 / 100 (totalDscMinted) = 0.9