### PR TITLE
:white_check_mark: fixed : Handler-burnDsc, adding approve

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -281,6 +281,10 @@ contract DSCEngine is ReentrancyGuard {
     function _burnDsc(uint256 amountDscToBurn, address onBehalfOf, address dscFrom) private {
         s_DSCMinted[onBehalfOf] -= amountDscToBurn;
 
+        if (onBehalfOf != dscFrom) {
+            s_DSCMinted[dscFrom] -= amountDscToBurn;
+        }
+
         bool success = i_dsc.transferFrom(dscFrom, address(this), amountDscToBurn);
         // This conditional is hypothetically unreachable
         if (!success) {

--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -74,7 +74,10 @@ contract StopOnRevertHandler is Test {
         if (amountDsc == 0) {
             return;
         }
+        vm.startPrank(msg.sender);
+        dsc.approve(address(dscEngine), amountDsc);
         dscEngine.burnDsc(amountDsc);
+        vm.stopPrank();
     }
 
     // Only the DSCEngine can mint DSC!

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -111,11 +111,7 @@ contract DSCEngineTest is StdCheats, Test {
         tokenAddresses = [address(mockDsc)];
         feedAddresses = [ethUsdPriceFeed];
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.mint(user, amountCollateral);
 
         vm.prank(owner);
@@ -207,11 +203,7 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses = [ethUsdPriceFeed];
         address owner = msg.sender;
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
@@ -231,7 +223,7 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
-    function testRevertsIfMintAmountBreaksHealthFactor() public depositedCollateral{
+    function testRevertsIfMintAmountBreaksHealthFactor() public depositedCollateral {
         // 0xe580cc6100000000000000000000000000000000000000000000000006f05b59d3b20000
         // 0xe580cc6100000000000000000000000000000000000000000000003635c9adc5dea00000
         (, int256 price,,,) = MockV3Aggregator(ethUsdPriceFeed).latestRoundData();
@@ -295,11 +287,7 @@ contract DSCEngineTest is StdCheats, Test {
         tokenAddresses = [address(mockDsc)];
         feedAddresses = [ethUsdPriceFeed];
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.mint(user, amountCollateral);
 
         vm.prank(owner);
@@ -399,11 +387,7 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses = [ethUsdPriceFeed];
         address owner = msg.sender;
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
@@ -486,9 +470,12 @@ contract DSCEngineTest is StdCheats, Test {
         assertEq(userCollateralValueInUsd, hardCodedExpectedValue);
     }
 
-    function testLiquidatorTakesOnUsersDebt() public liquidated {
-        (uint256 liquidatorDscMinted,) = dsce.getAccountInformation(liquidator);
-        assertEq(liquidatorDscMinted, amountToMint);
+    function test_LiquidatorHasNoDscAndNoDebtAfterLiquidation() public liquidated {
+        (uint256 liquidatorDscMinted,) = dscEngine.getAccountInformation(LIQUIDATOR);
+        uint256 liquidatorDscBalance = dsc.balanceOf(LIQUIDATOR);
+
+        assertEq(liquidatorDscMinted, 0);
+        assertEq(liquidatorDscBalance, 0);
     }
 
     function testUserHasNoMoreDebt() public liquidated {


### PR DESCRIPTION
Update StopOnRevertHandler.t.sol - fixing burnDsc (as a follow-up to #35 )

burnDsc reverts due to a ERC20InsufficientAllowance error.

The burnDsc function ends up calling _burnDsc where a dsc transfer is made. An 'approve' is therefore necessary before.
To perform this we must also 'prank' the msg.sender 