### PR TITLE
:white_check_mark: fixed : Handler-burnDsc, adding approve

### DIFF
--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -74,7 +74,10 @@ contract StopOnRevertHandler is Test {
         if (amountDsc == 0) {
             return;
         }
+        vm.startPrank(msg.sender);
+        dsc.approve(address(dscEngine), amountDsc);
         dscEngine.burnDsc(amountDsc);
+        vm.stopPrank();
     }
 
     // Only the DSCEngine can mint DSC!


### PR DESCRIPTION
Update StopOnRevertHandler.t.sol - fixing burnDsc (as a follow-up to https://github.com/Cyfrin/foundry-defi-stablecoin-f23/pull/35 )

burnDsc reverts due to a ERC20InsufficientAllowance error.

The burnDsc function ends up calling _burnDsc where a dsc transfer is made. An 'approve' is therefore necessary before.
To perform this we must also 'prank' the msg.sender