### PR TITLE
:adhesive_bandage: issue fixed : liquidator can not burn dsc

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -281,6 +281,10 @@ contract DSCEngine is ReentrancyGuard {
     function _burnDsc(uint256 amountDscToBurn, address onBehalfOf, address dscFrom) private {
         s_DSCMinted[onBehalfOf] -= amountDscToBurn;
 
+        if (onBehalfOf != dscFrom) {
+            s_DSCMinted[dscFrom] -= amountDscToBurn;
+        }
+
         bool success = i_dsc.transferFrom(dscFrom, address(this), amountDscToBurn);
         // This conditional is hypothetically unreachable
         if (!success) {

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -111,11 +111,7 @@ contract DSCEngineTest is StdCheats, Test {
         tokenAddresses = [address(mockDsc)];
         feedAddresses = [ethUsdPriceFeed];
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.mint(user, amountCollateral);
 
         vm.prank(owner);
@@ -207,11 +203,7 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses = [ethUsdPriceFeed];
         address owner = msg.sender;
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
@@ -231,7 +223,7 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
-    function testRevertsIfMintAmountBreaksHealthFactor() public depositedCollateral{
+    function testRevertsIfMintAmountBreaksHealthFactor() public depositedCollateral {
         // 0xe580cc6100000000000000000000000000000000000000000000000006f05b59d3b20000
         // 0xe580cc6100000000000000000000000000000000000000000000003635c9adc5dea00000
         (, int256 price,,,) = MockV3Aggregator(ethUsdPriceFeed).latestRoundData();
@@ -295,11 +287,7 @@ contract DSCEngineTest is StdCheats, Test {
         tokenAddresses = [address(mockDsc)];
         feedAddresses = [ethUsdPriceFeed];
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.mint(user, amountCollateral);
 
         vm.prank(owner);
@@ -399,11 +387,7 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses = [ethUsdPriceFeed];
         address owner = msg.sender;
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
@@ -486,9 +470,12 @@ contract DSCEngineTest is StdCheats, Test {
         assertEq(userCollateralValueInUsd, hardCodedExpectedValue);
     }
 
-    function testLiquidatorTakesOnUsersDebt() public liquidated {
-        (uint256 liquidatorDscMinted,) = dsce.getAccountInformation(liquidator);
-        assertEq(liquidatorDscMinted, amountToMint);
+    function test_LiquidatorHasNoDscAndNoDebtAfterLiquidation() public liquidated {
+        (uint256 liquidatorDscMinted,) = dscEngine.getAccountInformation(LIQUIDATOR);
+        uint256 liquidatorDscBalance = dsc.balanceOf(LIQUIDATOR);
+
+        assertEq(liquidatorDscMinted, 0);
+        assertEq(liquidatorDscBalance, 0);
     }
 
     function testUserHasNoMoreDebt() public liquidated {


### PR DESCRIPTION
~~Problem: after a liquidation the liquidator cannot burn his dsc.~~

This is not a security breach, however it is a big problem because the more a liquidator will liquidate the more its healthfactor will decrease if it does not add collateral. And since he can’t burn his dsc, he won’t be able to remove his collateral later. As such, **it could be considered that the protocol retains the liquidators' funds**.

In the facts what is blocking is the function `_burnDsc` which decreases the balance of DscMinted only for `onBehalfOf`
In the case of a liquidation `msg.sender` is different from `onBehalfOf`

For the general liquidation process:
- the liquidator must mint the dsc (and deposit collateral)
- during the liquidation:
  - the balance of `DscMinted` of `onBehalfOf` is reduced 
  - we transfer the dsc from the liquidator to burn them

It appears that after liquidation the liquidator still has a balance of `DscMinted` in the protocol while he no longer holds a dsc.
We did burn dsc but it’s his. `onBehalfOf` are just detaching from our accounts. He has no more debt but can do what he wants with his dsc (we took his collateral in exchange).

For the liquidator :
- The `redeemCollateralForDsc` function will fail because calling `burnDsc` first will have a revert: `ERC20InsufficientBalance`
- The `redeemCollateral` function will fail because ending with a health factor check, there will be a revert : `DSCEngine__BreaksHealthFactor`
- The liquidator cannot burn his dsc either, and so his collateral is blocked

The proposal is to add to `_burnDSC`: 
```
       if (onBehalfOf!= dscFrom) {
            s_DSCMinted[dscFrom] -= amountDscToBurn;
        }
```
In the case where the two addresses are different, it is a liquidation, so we release the liquidator of his debt.

Following this change, this test should also be deleted:
```
    function testLiquidatorTakesOnUsersDebt() public liquidated {
        (uint256 liquidatorDscMinted,) = dsce.getAccountInformation(liquidator);
        assertEq(liquidatorDscMinted, amountToMint);
    }
```
and replace with: 

```
    function test_LiquidatorHasNoDscAndNoDebtAfterLiquidation() public liquidated {
        (uint256 liquidatorDscMinted,) = dscEngine.getAccountInformation(LIQUIDATOR);
        uint256 liquidatorDscBalance = dsc.balanceOf(LIQUIDATOR);

        assertEq(liquidatorDscMinted, 0);
        assertEq(liquidatorDscBalance, 0);
    }
```

The liquidator pays well the debt of the liquidated since one transfers his dsc to burn them, but there is no reason, since he no longer has dsc, to have a debt to the protocol.

Placing the change in the `liquidate` function before calling `burn` could save some gas however it would be less clear. Since it is in the logic of `_burnDsc` that this operation must be carried out, if in the future other modifications are made, dissociating this modification from `_burnDsc` can lead to confusions and errors.


I have not yet found any discussion on this subject, I may have misunderstood something, in this case excuse my misunderstanding and tell me where I am wrong.
But in my opinion the liquidator cannot burn his dsc is an issue.