### PR TITLE
Adding in-line config to invariant tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean  :; forge clean
 # Remove modules
 remove :; rm -rf .gitmodules && rm -rf .git/modules/* && rm -rf lib && touch .gitmodules && git add . && git commit -m "modules"
 
-install :; forge install cyfrin/foundry-devops@0.0.11 --no-commit && forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit && forge install foundry-rs/forge-std@v1.5.3 --no-commit && forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit
+install :; forge install cyfrin/foundry-devops@0.1.0 --no-commit && forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit && forge install foundry-rs/forge-std@v1.5.3 --no-commit && forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit
 
 # Update Dependencies
 update:; forge update

--- a/script/DeployDSC.s.sol
+++ b/script/DeployDSC.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import { Script } from "forge-std/Script.sol";
 import { HelperConfig } from "./HelperConfig.s.sol";

--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import { MockV3Aggregator } from "../test/mocks/MockV3Aggregator.sol";
 import { Script } from "forge-std/Script.sol";

--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -22,7 +22,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { OracleLib, AggregatorV3Interface } from "./libraries/OracleLib.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";

--- a/src/DecentralizedStableCoin.sol
+++ b/src/DecentralizedStableCoin.sol
@@ -23,7 +23,7 @@
 // private
 // view & pure functions
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ERC20Burnable, ERC20 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/src/libraries/OracleLib.sol
+++ b/src/libraries/OracleLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol
@@ -2,137 +2,113 @@
 
 // // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.19;
 
-// import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-// import {Test} from "forge-std/Test.sol";
-// import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
 
-// import {MockV3Aggregator} from "../../mocks/MockV3Aggregator.sol";
-// import {DSCEngine, AggregatorV3Interface} from "../../../src/DSCEngine.sol";
-// import {DecentralizedStableCoin} from "../../../src/DecentralizedStableCoin.sol";
-// import {Randomish, EnumerableSet} from "../Randomish.sol";
-// import {MockV3Aggregator} from "../../mocks/MockV3Aggregator.sol";
-// import {console} from "forge-std/console.sol";
+import { MockV3Aggregator } from "../../mocks/MockV3Aggregator.sol";
+import { DSCEngine, AggregatorV3Interface } from "../../../src/DSCEngine.sol";
+import { DecentralizedStableCoin } from "../../../src/DecentralizedStableCoin.sol";
+// import {Randomish, EnumerableSet} from "../Randomish.sol"; // Randomish is not found in the codebase, EnumerableSet
+// is imported from openzeppelin
+import { MockV3Aggregator } from "../../mocks/MockV3Aggregator.sol";
+import { console } from "forge-std/console.sol";
 
-// contract ContinueOnRevertHandler is Test {
-//     using EnumerableSet for EnumerableSet.AddressSet;
-//     using Randomish for EnumerableSet.AddressSet;
+contract ContinueOnRevertHandler is Test {
+    // using EnumerableSet for EnumerableSet.AddressSet;
+    // using Randomish for EnumerableSet.AddressSet;
 
-//     // Deployed contracts to interact with
-//     DSCEngine public dscEngine;
-//     DecentralizedStableCoin public dsc;
-//     MockV3Aggregator public ethUsdPriceFeed;
-//     MockV3Aggregator public btcUsdPriceFeed;
-//     ERC20Mock public weth;
-//     ERC20Mock public wbtc;
+    // Deployed contracts to interact with
+    DSCEngine public dscEngine;
+    DecentralizedStableCoin public dsc;
+    MockV3Aggregator public ethUsdPriceFeed;
+    MockV3Aggregator public btcUsdPriceFeed;
+    ERC20Mock public weth;
+    ERC20Mock public wbtc;
 
-//     // Ghost Variables
-//     uint96 public constant MAX_DEPOSIT_SIZE = type(uint96).max;
+    // Ghost Variables
+    uint96 public constant MAX_DEPOSIT_SIZE = type(uint96).max;
 
-//     constructor(DSCEngine _dscEngine, DecentralizedStableCoin _dsc) {
-//         dscEngine = _dscEngine;
-//         dsc = _dsc;
+    constructor(DSCEngine _dscEngine, DecentralizedStableCoin _dsc) {
+        dscEngine = _dscEngine;
+        dsc = _dsc;
 
-//         address[] memory collateralTokens = dscEngine.getCollateralTokens();
-//         weth = ERC20Mock(collateralTokens[0]);
-//         wbtc = ERC20Mock(collateralTokens[1]);
+        address[] memory collateralTokens = dscEngine.getCollateralTokens();
+        weth = ERC20Mock(collateralTokens[0]);
+        wbtc = ERC20Mock(collateralTokens[1]);
 
-//         ethUsdPriceFeed = MockV3Aggregator(
-//             dscEngine.getCollateralTokenPriceFeed(address(weth))
-//         );
-//         btcUsdPriceFeed = MockV3Aggregator(
-//             dscEngine.getCollateralTokenPriceFeed(address(wbtc))
-//         );
-//     }
+        ethUsdPriceFeed = MockV3Aggregator(dscEngine.getCollateralTokenPriceFeed(address(weth)));
+        btcUsdPriceFeed = MockV3Aggregator(dscEngine.getCollateralTokenPriceFeed(address(wbtc)));
+    }
 
-//     // FUNCTOINS TO INTERACT WITH
+    // FUNCTOINS TO INTERACT WITH
 
-//     ///////////////
-//     // DSCEngine //
-//     ///////////////
-//     function mintAndDepositCollateral(
-//         uint256 collateralSeed,
-//         uint256 amountCollateral
-//     ) public {
-//         amountCollateral = bound(amountCollateral, 0, MAX_DEPOSIT_SIZE);
-//         ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
-//         collateral.mint(msg.sender, amountCollateral);
-//         dscEngine.depositCollateral(address(collateral), amountCollateral);
-//     }
+    ///////////////
+    // DSCEngine //
+    ///////////////
+    function mintAndDepositCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
+        amountCollateral = bound(amountCollateral, 0, MAX_DEPOSIT_SIZE);
+        ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
+        collateral.mint(msg.sender, amountCollateral);
+        dscEngine.depositCollateral(address(collateral), amountCollateral);
+    }
 
-//     function redeemCollateral(
-//         uint256 collateralSeed,
-//         uint256 amountCollateral
-//     ) public {
-//         amountCollateral = bound(amountCollateral, 0, MAX_DEPOSIT_SIZE);
-//         ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
-//         dscEngine.redeemCollateral(address(collateral), amountCollateral);
-//     }
+    function redeemCollateral(uint256 collateralSeed, uint256 amountCollateral) public {
+        amountCollateral = bound(amountCollateral, 0, MAX_DEPOSIT_SIZE);
+        ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
+        dscEngine.redeemCollateral(address(collateral), amountCollateral);
+    }
 
-//     function burnDsc(uint256 amountDsc) public {
-//         amountDsc = bound(amountDsc, 0, dsc.balanceOf(msg.sender));
-//         dsc.burn(amountDsc);
-//     }
+    function burnDsc(uint256 amountDsc) public {
+        amountDsc = bound(amountDsc, 0, dsc.balanceOf(msg.sender));
+        dsc.burn(amountDsc);
+    }
 
-//     function mintDsc(uint256 amountDsc) public {
-//         amountDsc = bound(amountDsc, 0, MAX_DEPOSIT_SIZE);
-//         dsc.mint(msg.sender, amountDsc);
-//     }
+    function mintDsc(uint256 amountDsc) public {
+        amountDsc = bound(amountDsc, 0, MAX_DEPOSIT_SIZE);
+        dsc.mint(msg.sender, amountDsc);
+    }
 
-//     function liquidate(
-//         uint256 collateralSeed,
-//         address userToBeLiquidated,
-//         uint256 debtToCover
-//     ) public {
-//         ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
-//         dscEngine.liquidate(
-//             address(collateral),
-//             userToBeLiquidated,
-//             debtToCover
-//         );
-//     }
+    function liquidate(uint256 collateralSeed, address userToBeLiquidated, uint256 debtToCover) public {
+        ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
+        dscEngine.liquidate(address(collateral), userToBeLiquidated, debtToCover);
+    }
 
-//     /////////////////////////////
-//     // DecentralizedStableCoin //
-//     /////////////////////////////
-//     function transferDsc(uint256 amountDsc, address to) public {
-//         amountDsc = bound(amountDsc, 0, dsc.balanceOf(msg.sender));
-//         vm.prank(msg.sender);
-//         dsc.transfer(to, amountDsc);
-//     }
+    /////////////////////////////
+    // DecentralizedStableCoin //
+    /////////////////////////////
+    function transferDsc(uint256 amountDsc, address to) public {
+        amountDsc = bound(amountDsc, 0, dsc.balanceOf(msg.sender));
+        vm.prank(msg.sender);
+        dsc.transfer(to, amountDsc);
+    }
 
-//     /////////////////////////////
-//     // Aggregator //
-//     /////////////////////////////
-//     function updateCollateralPrice(
-//         uint128 newPrice,
-//         uint256 collateralSeed
-//     ) public {
-//         // int256 intNewPrice = int256(uint256(newPrice));
-//         int256 intNewPrice = 0;
-//         ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
-//         MockV3Aggregator priceFeed = MockV3Aggregator(
-//             dscEngine.getCollateralTokenPriceFeed(address(collateral))
-//         );
+    /////////////////////////////
+    // Aggregator //
+    /////////////////////////////
+    function updateCollateralPrice(uint128 newPrice, uint256 collateralSeed) public {
+        // int256 intNewPrice = int256(uint256(newPrice));
+        int256 intNewPrice = 0;
+        ERC20Mock collateral = _getCollateralFromSeed(collateralSeed);
+        MockV3Aggregator priceFeed = MockV3Aggregator(dscEngine.getCollateralTokenPriceFeed(address(collateral)));
 
-//         priceFeed.updateAnswer(intNewPrice);
-//     }
+        priceFeed.updateAnswer(intNewPrice);
+    }
 
-//     /// Helper Functions
-//     function _getCollateralFromSeed(
-//         uint256 collateralSeed
-//     ) private view returns (ERC20Mock) {
-//         if (collateralSeed % 2 == 0) {
-//             return weth;
-//         } else {
-//             return wbtc;
-//         }
-//     }
+    /// Helper Functions
+    function _getCollateralFromSeed(uint256 collateralSeed) private view returns (ERC20Mock) {
+        if (collateralSeed % 2 == 0) {
+            return weth;
+        } else {
+            return wbtc;
+        }
+    }
 
-//     function callSummary() external view {
-//         console.log("Weth total deposited", weth.balanceOf(address(dscEngine)));
-//         console.log("Wbtc total deposited", wbtc.balanceOf(address(dscEngine)));
-//         console.log("Total supply of DSC", dsc.totalSupply());
-//     }
-// }
+    function callSummary() external view {
+        console.log("Weth total deposited", weth.balanceOf(address(dscEngine)));
+        console.log("Wbtc total deposited", wbtc.balanceOf(address(dscEngine)));
+        console.log("Total supply of DSC", dsc.totalSupply());
+    }
+}

--- a/test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol
@@ -2,7 +2,7 @@
 
 // // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 // import {Test} from "forge-std/Test.sol";

--- a/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
@@ -2,77 +2,75 @@
 
 // // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.19;
 
 // // Invariants:
 // // protocol must never be insolvent / undercollateralized
 // // users cant create stablecoins with a bad health factor
 // // a user should only be able to be liquidated if they have a bad health factor
 
-// import {Test} from "forge-std/Test.sol";
-// import {StdInvariant} from "forge-std/StdInvariant.sol";
-// import {DSCEngine} from "../../../src/DSCEngine.sol";
-// import {DecentralizedStableCoin} from "../../../src/DecentralizedStableCoin.sol";
-// import {HelperConfig} from "../../../script/HelperConfig.s.sol";
-// import {DeployDSC} from "../../../script/DeployDSC.s.sol";
-// import {ERC20Mock} from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
-// import {ContinueOnRevertHandler} from "./ContinueOnRevertHandler.t.sol";
-// import {console} from "forge-std/console.sol";
+import { Test } from "forge-std/Test.sol";
+import { StdInvariant } from "forge-std/StdInvariant.sol";
+import { DSCEngine } from "../../../src/DSCEngine.sol";
+import { DecentralizedStableCoin } from "../../../src/DecentralizedStableCoin.sol";
+import { HelperConfig } from "../../../script/HelperConfig.s.sol";
+import { DeployDSC } from "../../../script/DeployDSC.s.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
+import { ContinueOnRevertHandler } from "./ContinueOnRevertHandler.t.sol";
+import { console } from "forge-std/console.sol";
 
-// contract ContinueOnRevertInvariants is StdInvariant, Test {
-//     DSCEngine public dsce;
-//     DecentralizedStableCoin public dsc;
-//     HelperConfig public helperConfig;
+contract ContinueOnRevertInvariants is StdInvariant, Test {
+    DSCEngine public dsce;
+    DecentralizedStableCoin public dsc;
+    HelperConfig public helperConfig;
 
-//     address public ethUsdPriceFeed;
-//     address public btcUsdPriceFeed;
-//     address public weth;
-//     address public wbtc;
+    address public ethUsdPriceFeed;
+    address public btcUsdPriceFeed;
+    address public weth;
+    address public wbtc;
 
-//     uint256 amountCollateral = 10 ether;
-//     uint256 amountToMint = 100 ether;
+    uint256 amountCollateral = 10 ether;
+    uint256 amountToMint = 100 ether;
 
-//     uint256 public constant STARTING_USER_BALANCE = 10 ether;
-//     address public constant USER = address(1);
-//     uint256 public constant MIN_HEALTH_FACTOR = 1e18;
-//     uint256 public constant LIQUIDATION_THRESHOLD = 50;
+    uint256 public constant STARTING_USER_BALANCE = 10 ether;
+    address public constant USER = address(1);
+    uint256 public constant MIN_HEALTH_FACTOR = 1e18;
+    uint256 public constant LIQUIDATION_THRESHOLD = 50;
 
-//     // Liquidation
-//     address public liquidator = makeAddr("liquidator");
-//     uint256 public collateralToCover = 20 ether;
+    // Liquidation
+    address public liquidator = makeAddr("liquidator");
+    uint256 public collateralToCover = 20 ether;
 
-//     ContinueOnRevertHandler public handler;
+    ContinueOnRevertHandler public handler;
 
-//     function setUp() external {
-//         DeployDSC deployer = new DeployDSC();
-//         (dsc, dsce, helperConfig) = deployer.run();
-//         (ethUsdPriceFeed, btcUsdPriceFeed, weth, wbtc) = helperConfig
-//             .activeNetworkConfig();
-//         handler = new ContinueOnRevertHandler(dsce, dsc);
-//         targetContract(address(handler));
-//         // targetContract(address(ethUsdPriceFeed)); Why can't we just do this?
-//     }
+    function setUp() external {
+        DeployDSC deployer = new DeployDSC();
+        (dsc, dsce, helperConfig) = deployer.run();
+        (ethUsdPriceFeed, btcUsdPriceFeed, weth, wbtc,) = helperConfig.activeNetworkConfig();
+        handler = new ContinueOnRevertHandler(dsce, dsc);
+        targetContract(address(handler));
+        // targetContract(address(ethUsdPriceFeed));// Why can't we just do this?
+    }
 
-//     function invariant_protocolMustHaveMoreValueThatTotalSupplyDollars()
-//         public
-//         view
-//     {
-//         uint256 totalSupply = dsc.totalSupply();
-//         uint256 wethDeposted = ERC20Mock(weth).balanceOf(address(dsce));
-//         uint256 wbtcDeposited = ERC20Mock(wbtc).balanceOf(address(dsce));
+    /// forge-config: default.invariant.fail-on-revert = false
+    function invariant_protocolMustHaveMoreValueThatTotalSupplyDollars() public view {
+        uint256 totalSupply = dsc.totalSupply();
+        uint256 wethDeposted = ERC20Mock(weth).balanceOf(address(dsce));
+        uint256 wbtcDeposited = ERC20Mock(wbtc).balanceOf(address(dsce));
 
-//         uint256 wethValue = dsce.getUsdValue(weth, wethDeposted);
-//         uint256 wbtcValue = dsce.getUsdValue(wbtc, wbtcDeposited);
+        uint256 wethValue = dsce.getUsdValue(weth, wethDeposted);
+        uint256 wbtcValue = dsce.getUsdValue(wbtc, wbtcDeposited);
 
-//         console.log("wethValue: %s", wethValue);
-//         console.log("wbtcValue: %s", wbtcValue);
+        console.log("wethValue: %s", wethValue);
+        console.log("wbtcValue: %s", wbtcValue);
 
-//         assert(wethValue + wbtcValue >= totalSupply);
-//     }
+        assert(wethValue + wbtcValue >= totalSupply);
+    }
 
-//     // function invariant_userCantCreateStabelcoinWithPoorHealthFactor() public {}
+    // function invariant_userCantCreateStabelcoinWithPoorHealthFactor() public {}
 
-//     function invariant_callSummary() public view {
-//         handler.callSummary();
-//     }
-// }
+    /// forge-config: default.invariant.fail-on-revert = false
+    function invariant_callSummary() public view {
+        handler.callSummary();
+    }
+}

--- a/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
@@ -2,7 +2,7 @@
 
 // // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // // Invariants:
 // // protocol must never be insolvent / undercollateralized

--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -61,7 +61,7 @@ contract StopOnRevertHandler is Test {
         uint256 maxCollateral = dscEngine.getCollateralBalanceOfUser(msg.sender, address(collateral));
 
         amountCollateral = bound(amountCollateral, 0, maxCollateral);
-        vm.prank(msg.sender);
+        //vm.prank(msg.sender);
         if (amountCollateral == 0) {
             return;
         }

--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { Test } from "forge-std/Test.sol";

--- a/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.25;
 
 // Invariants:
 // protocol must never be insolvent / undercollateralized

--- a/test/mocks/ERC20Mock.sol
+++ b/test/mocks/ERC20Mock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20Mock is ERC20 {
+    constructor(
+        string memory name,
+        string memory symbol,
+        address initialAccount,
+        uint256 initialBalance
+    )
+        payable
+        ERC20(name, symbol)
+    {
+        _mint(initialAccount, initialBalance);
+    }
+
+    function mint(address account, uint256 amount) public {
+        _mint(account, amount);
+    }
+
+    function burn(address account, uint256 amount) public {
+        _burn(account, amount);
+    }
+
+    function transferInternal(address from, address to, uint256 value) public {
+        _transfer(from, to, value);
+    }
+
+    function approveInternal(address owner, address spender, uint256 value) public {
+        _approve(owner, spender, value);
+    }
+}

--- a/test/mocks/MockFailedMintDSC.sol
+++ b/test/mocks/MockFailedMintDSC.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ERC20Burnable, ERC20 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/mocks/MockFailedTransfer.sol
+++ b/test/mocks/MockFailedTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ERC20Burnable, ERC20 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/mocks/MockFailedTransferFrom.sol
+++ b/test/mocks/MockFailedTransferFrom.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ERC20Burnable, ERC20 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/mocks/MockMoreDebtDSC.sol
+++ b/test/mocks/MockMoreDebtDSC.sol
@@ -23,7 +23,7 @@
 // private
 // view & pure functions
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { ERC20Burnable, ERC20 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { DeployDSC } from "../../script/DeployDSC.s.sol";
 import { DSCEngine } from "../../src/DSCEngine.sol";

--- a/test/unit/DecentralizedStablecoinTest.t.sol
+++ b/test/unit/DecentralizedStablecoinTest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { DecentralizedStableCoin } from "../../src/DecentralizedStableCoin.sol";
 import { Test, console } from "forge-std/Test.sol";

--- a/test/unit/OracleLibTest.t.sol
+++ b/test/unit/OracleLibTest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.19;
+pragma solidity 0.8.25;
 
 import { MockV3Aggregator } from "../mocks/MockV3Aggregator.sol";
 import { Test, console } from "forge-std/Test.sol";


### PR DESCRIPTION
# Description
In this [lesson](https://updraft.cyfrin.io/courses/advanced-foundry/develop-defi-protocol/defi-handler-redeeming-collateral) Patrick mentions the possibility of integrate inline config to make tests fail or don't fail on revert.


I discovered that foundry [now allow this possibility](https://book.getfoundry.sh/reference/config/inline-test-config) 

With this PR I'm just using foundry inline test config to make the `ContinueOnRevert` tests work.

## Demo
See how we have all invariant tests working: some of them have 0 revert and others have some.
![Schermata 2024-04-09 alle 09 19 34](https://github.com/Cyfrin/foundry-defi-stablecoin-f23/assets/46995085/6b2c17dd-0e86-4cff-aea3-b3b797f05353)

## Other things
Additionally,
- I updated Solidity version to 0.8.25 
- I updated version of cyfrin/foundry-devops to 0.1.0

I'm not sure that this updates will be ok in order to merge the PR - I did this because the project couldn't run on my mac otherwise
