### PR TITLE
Fix: Repair broken internal links for proper document navigation in audit report

### DIFF
--- a/audits/codehawks-08-05-2023.md
+++ b/audits/codehawks-08-05-2023.md
@@ -68,7 +68,7 @@
     - [G-36. Imports could be organized more systematically](#g-36-imports-could-be-organized-more-systematically)
     - [G-37. Unnecessary argument in getTimeout function](#g-37-unnecessary-argument-in-gettimeout-function)
     - [G-38. Not respecting the Checks-Effects-Interactions pattern that can be a place for bugs](#g-38-not-respecting-the-checks-effects-interactions-pattern-that-can-be-a-place-for-bugs)
-    - [G-39. >= costs less gas than >](#g-39--costs-less-gas-than)
+    - [G-39. >= costs less gas than >](#g-39--costs-less-gas-than-)
     - [G-40. [L-03] Continues with the standard use for Collateral variable](#g-40-l-03-continues-with-the-standard-use-for-collateral-variable)
     - [G-41. Wrong comment DecentralizedStableCoin.sol](#g-41-wrong-comment-decentralizedstablecoinsol)
     - [G-42. Consider disabling renounceOwnership()](#g-42-consider-disabling-renounceownership)


### PR DESCRIPTION
While reading the audit report, I noticed some links under the `Table of contents` section that were broken, i.e., one can't jump right away to any particular vulnerability. Hence, there's a need to fix them.

Earlier, links were implemented like this: `[H-01. Theft of collateral tokens with fewer than 18 decimals](#H-01)`. Here, `#H-01` represents the anchor Id for `## <a id='H-01'></a>H-01. Theft of collateral tokens with fewer than 18 decimals`. Somehow, this just works in the visual code, but neither on the GitHub site nor right-clicking on the link and "Open a New Tab" works.

Changing `[H-01. Theft of collateral tokens with fewer than 18 decimals](#H-01)` to `[H-01. Theft of collateral tokens with fewer than 18 decimals](#h-01-theft-of-collateral-tokens-with-fewer-than-18-decimals)` solves the issue. Now, most of the links under the `Table of contents` section use this approach.

However, `G-39` was a special case due to the way its link had to be created. The link of `G-39` won't work in VS Code, but runs fine on the GitHub site.

Along with that, this PR also fixes some typos that I discovered during this whole process.