### PR TITLE
update testCannotMintWithoutDepositingCollateral + forge remapping

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,14 @@
+{
+  "lib/chainlink-brownie-contracts": {
+    "rev": "5cb41fbc9b525338b6098da5ea7dd0b7e92f89e4"
+  },
+  "lib/forge-std": {
+    "rev": "fc560fa34fa12a335a50c35d92e55a6628ca467c"
+  },
+  "lib/foundry-devops": {
+    "rev": "d4a3bb4e5937e71193d943ea73ec2a6362cbe400"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "0a25c1940ca220686588c4af3ec526f725fe2582"
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 remappings = [
     '@chainlink/contracts/=lib/chainlink-brownie-contracts/contracts/',
     '@openzeppelin/contracts=lib/openzeppelin-contracts/contracts',
+    'forge-std/=lib/forge-std/src/',
 ]
 
 [etherscan]

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -18,7 +18,7 @@ import { StdCheats } from "forge-std/StdCheats.sol";
 
 contract DSCEngineTest is StdCheats, Test {
     event CollateralRedeemed(address indexed redeemFrom, address indexed redeemTo, address token, uint256 amount); // if
-        // redeemFrom != redeemedTo, then it was liquidated
+    // redeemFrom != redeemedTo, then it was liquidated
 
     DSCEngine public dsce;
     DecentralizedStableCoin public dsc;
@@ -243,16 +243,14 @@ contract DSCEngineTest is StdCheats, Test {
     }
 
     function testCannotMintWithoutDepositingCollateral() public {
-    vm.startPrank(user);
+        vm.startPrank(user);
 
-    // Do NOT deposit collateral; do NOT approve anything.
-    // Try to mint — should revert because health factor will be broken.
-    vm.expectRevert(
-        abi.encodeWithSelector(DSCEngine.DSCEngine__BreakHealthFactor.selector)
-    );
-    dsce.mintDsc(amountToMint);
+        // Do NOT deposit collateral; do NOT approve anything.
+        // Try to mint — should revert because health factor will be broken.
+        vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__BreaksHealthFactor.selector, 0));
+        dsce.mintDsc(amountToMint);
 
-    vm.stopPrank();
+        vm.stopPrank();
     }
 
     ///////////////////////////////////
@@ -463,7 +461,9 @@ contract DSCEngineTest is StdCheats, Test {
     function testLiquidationPayoutIsCorrect() public liquidated {
         uint256 liquidatorWethBalance = ERC20Mock(weth).balanceOf(liquidator);
         uint256 expectedWeth = dsce.getTokenAmountFromUsd(weth, amountToMint)
-            + (dsce.getTokenAmountFromUsd(weth, amountToMint) * dsce.getLiquidationBonus() / dsce.getLiquidationPrecision());
+            + (dsce.getTokenAmountFromUsd(weth, amountToMint)
+                * dsce.getLiquidationBonus()
+                / dsce.getLiquidationPrecision());
         uint256 hardCodedExpected = 6_111_111_111_111_111_110;
         assertEq(liquidatorWethBalance, hardCodedExpected);
         assertEq(liquidatorWethBalance, expectedWeth);
@@ -472,7 +472,9 @@ contract DSCEngineTest is StdCheats, Test {
     function testUserStillHasSomeEthAfterLiquidation() public liquidated {
         // Get how much WETH the user lost
         uint256 amountLiquidated = dsce.getTokenAmountFromUsd(weth, amountToMint)
-            + (dsce.getTokenAmountFromUsd(weth, amountToMint) * dsce.getLiquidationBonus() / dsce.getLiquidationPrecision());
+            + (dsce.getTokenAmountFromUsd(weth, amountToMint)
+                * dsce.getLiquidationBonus()
+                / dsce.getLiquidationPrecision());
 
         uint256 usdAmountLiquidated = dsce.getUsdValue(weth, amountLiquidated);
         uint256 expectedUserCollateralValueInUsd = dsce.getUsdValue(weth, amountCollateral) - (usdAmountLiquidated);


### PR DESCRIPTION
## Summary
- Added forge remapping to foundry.toml to resolve errors in DSCEngineTest.t.sol
- Resolved error in `DSCEngineTest::testCannotMintWithoutDepositingCollateral.` The `DSCEngine__BreaksHealthFactor` error expected a `uint256 healthFactorValue` parameter, but didn't have any.

## Tests 
``` forge test ```