### PR TITLE
Refactored the testRevertsIfTransferFails unit test to use local memory arrays instead of global storage variables.

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -292,25 +292,32 @@ contract DSCEngineTest is StdCheats, Test {
     function testRevertsIfTransferFails() public {
         // Arrange - Setup
         address owner = msg.sender;
-        vm.prank(owner);
+        vm.startPrank(owner);
         MockFailedTransfer mockDsc = new MockFailedTransfer();
-        tokenAddresses = [address(mockDsc)];
-        feedAddresses = [ethUsdPriceFeed];
-        vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
-        mockDsc.mint(user, amountCollateral);
+    
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(mockDsc);
+        address[] memory feeds = new address[](1);
+        feeds[0] = ethUsdPriceFeed;
 
-        vm.prank(owner);
+        DSCEngine mockDsce = new DSCEngine(tokens, feeds, address(mockDsc));
+
+        mockDsc.mint(user, amountCollateral);
         mockDsc.transferOwnership(address(mockDsce));
+        vm.stopPrank(); 
+
         // Arrange - User
         vm.startPrank(user);
         ERC20Mock(address(mockDsc)).approve(address(mockDsce), amountCollateral);
+
         // Act / Assert
         mockDsce.depositCollateral(address(mockDsc), amountCollateral);
+
         vm.expectRevert(DSCEngine.DSCEngine__TransferFailed.selector);
         mockDsce.redeemCollateral(address(mockDsc), amountCollateral);
         vm.stopPrank();
     }
+
 
     function testRevertsIfRedeemAmountIsZero() public {
         vm.startPrank(user);


### PR DESCRIPTION
## Summary
Refactored the `testRevertsIfTransferFails` unit test to use local memory arrays instead of global storage variables.

## The "Why"
The previous implementation relied on the global `tokenAddresses` state variable.
- **Risk:** modifying global state in a unit test can lead to "side effects," where one test accidentally breaks another test because the variables weren't reset properly.
- **Fix:** By initializing `address[] memory tokens` strictly inside the test function, we ensure this test is completely isolated and self-contained.

## Changes
- Created temporary `address[] memory` arrays for passing tokens and feeds to the constructor.
- Replaced repetitive `vm.prank` calls with a cleaner `vm.startPrank` / `vm.stopPrank` block.
- Confirmed the test passes and correctly expects the revert.